### PR TITLE
fix: reference link submitted by the mentee is now clickable in mentor-evaluation page

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<queries>
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="http" />
+    </intent>
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" />
+    </intent>
+</queries>
+
 <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="ammentor"

--- a/lib/screen/mentor-evaluation/view/evaluation_screen.dart
+++ b/lib/screen/mentor-evaluation/view/evaluation_screen.dart
@@ -5,6 +5,7 @@ import 'package:ammentor/components/theme.dart';
 import 'package:ammentor/screen/mentor-evaluation/model/evaluation_model.dart';
 import 'package:ammentor/screen/mentor-evaluation/model/mentee_tasks_model.dart';
 import 'package:ammentor/screen/mentor-evaluation/provider/evaluation_provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class TaskEvaluationScreen extends ConsumerStatefulWidget {
   final Task task;
@@ -87,7 +88,8 @@ class _TaskEvaluationScreenState extends ConsumerState<TaskEvaluationScreen> {
 
             TextFormField(
               controller: _remarksController,
-              onChanged: (val) => ref.read(taskEvaluationControllerProvider(widget.task).notifier).updateFeedback(val),
+              onChanged: (val) =>
+                  ref.read(taskEvaluationControllerProvider(widget.task).notifier).updateFeedback(val),
               maxLines: 6,
               style: AppTextStyles.input(context).copyWith(color: Colors.white),
               cursorColor: Colors.white,
@@ -161,19 +163,38 @@ class _TaskEvaluationScreenState extends ConsumerState<TaskEvaluationScreen> {
     final w = MediaQuery.of(context).size.width;
     final h = MediaQuery.of(context).size.height;
 
+    final isLink = text.startsWith("http");
+
+    Future<void> _openLink(String url) async {
+      final uri = Uri.tryParse(url);
+      if (uri != null && await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text("Invalid or unreachable link")),
+        );
+      }
+    }
+
     return Padding(
       padding: EdgeInsets.symmetric(vertical: h * 0.01),
-      child: Row(
-        children: [
-          Icon(icon, size: w * 0.048, color: AppColors.grey),
-          SizedBox(width: w * 0.03),
-          Expanded(
-            child: Text(
-              text,
-              style: AppTextStyles.caption(context).copyWith(color: Colors.white),
+      child: InkWell(
+        onTap: isLink ? () => _openLink(text) : null,
+        child: Row(
+          children: [
+            Icon(icon, size: w * 0.048, color: AppColors.grey),
+            SizedBox(width: w * 0.03),
+            Expanded(
+              child: Text(
+                text,
+                style: AppTextStyles.caption(context).copyWith(
+                  color: isLink ? Colors.blue : Colors.white,
+                  decoration: isLink ? TextDecoration.underline : null,
+                ),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -872,13 +872,13 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   shared_preferences: ^2.2.2
   flutter_secure_storage: ^9.2.4
   table_calendar: ^3.0.9  
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR solves the reference link issue in mentor-evaluation page, the mentor can now click on the link submitted by the mentee and it redirects to the respective webpage.