### PR TITLE
fix: text and link detection

### DIFF
--- a/lib/components/link_text.dart
+++ b/lib/components/link_text.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:ammentor/components/theme.dart';
+
+class LinkText extends StatelessWidget {
+  final String text;
+  final TextStyle? style;
+  final int maxLines;
+
+  const LinkText({
+    super.key,
+    required this.text,
+    this.style,
+    this.maxLines = 3,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final regex = RegExp(r'(https?:\/\/[^\s]+|www\.[^\s]+)');
+    final match = regex.firstMatch(text);
+
+    if (match == null) {
+      return Text(
+        text,
+        style: style ?? AppTextStyles.caption(context).copyWith(color: Colors.white),
+        maxLines: maxLines,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    final before = text.substring(0, match.start);
+    final url = match.group(0)!;
+    final after = text.substring(match.end);
+
+    return RichText(
+      maxLines: maxLines,
+      overflow: TextOverflow.ellipsis,
+      text: TextSpan(
+        style: style ?? AppTextStyles.caption(context).copyWith(color: Colors.white),
+        children: [
+          TextSpan(text: before),
+          TextSpan(
+            text: url,
+            style: AppTextStyles.caption(context).copyWith(
+              color: Colors.blue,
+              decoration: TextDecoration.underline,
+            ),
+            recognizer: TapGestureRecognizer()
+              ..onTap = () async {
+                String normalized = url;
+                if (!normalized.startsWith('http')) {
+                  normalized = 'https://$normalized';
+                }
+                final uri = Uri.parse(normalized);
+                if (await canLaunchUrl(uri)) {
+                  await launchUrl(uri, mode: LaunchMode.externalApplication);
+                }
+              },
+          ),
+          TextSpan(text: after),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screen/mentee-submissions/view/submission_details_screen.dart
+++ b/lib/screen/mentee-submissions/view/submission_details_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:url_launcher/url_launcher.dart';
+// import 'package:url_launcher/url_launcher.dart';
 import 'package:ammentor/components/theme.dart';
 import 'package:ammentor/screen/mentee-submissions/model/submission_model.dart';
+import 'package:ammentor/components/link_text.dart';
 
 class SubmissionDetailsScreen extends StatelessWidget {
   final Submission submission;
@@ -13,6 +14,7 @@ class SubmissionDetailsScreen extends StatelessWidget {
     if (date == null) return 'Pending';
     return DateFormat('dd MMM yyyy').format(date);
   }
+
 
   Widget buildInfoCard(
     BuildContext context,
@@ -84,25 +86,12 @@ class SubmissionDetailsScreen extends StatelessWidget {
                           ),
                         ),
                       )
-                    : isLink
-                        ? GestureDetector(
-                            onTap: () async {
-                              final uri = Uri.parse(value);
-                              if (await canLaunchUrl(uri)) {
-                                await launchUrl(uri, mode: LaunchMode.externalApplication);
-                              }
-                            },
-                            child: Text(
-                              value,
-                              style: AppTextStyles.link(context).copyWith(fontWeight: FontWeight.w500),
-                            ),
-                          )
-                        : Text(
-                            value,
-                            style: AppTextStyles.body(context).copyWith(
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
+                    : LinkText(
+                        text: value,
+                        style: AppTextStyles.body(context).copyWith(
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
               ],
             ),
           ),

--- a/lib/screen/mentor-evaluation/view/evaluation_screen_pending_tasks.dart
+++ b/lib/screen/mentor-evaluation/view/evaluation_screen_pending_tasks.dart
@@ -1,3 +1,4 @@
+import 'package:ammentor/components/link_text.dart';
 import 'package:flutter/material.dart';
 import 'package:hugeicons/hugeicons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -5,7 +6,6 @@ import 'package:ammentor/components/theme.dart';
 import 'package:ammentor/screen/mentor-evaluation/model/evaluation_model.dart';
 import 'package:ammentor/screen/mentor-evaluation/model/mentee_tasks_model.dart';
 import 'package:ammentor/screen/mentor-evaluation/provider/evaluation_provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class TaskEvaluationScreen extends ConsumerStatefulWidget {
   final Task task;
@@ -164,39 +164,23 @@ class _TaskEvaluationScreenState extends ConsumerState<TaskEvaluationScreen> {
     final w = MediaQuery.of(context).size.width;
     final h = MediaQuery.of(context).size.height;
 
-    final isLink = text.startsWith("http");
-
-    Future<void> _openLink(String url) async {
-      final uri = Uri.tryParse(url);
-      if (uri != null && await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text("Invalid or unreachable link")),
-        );
-      }
-    }
-
     return Padding(
       padding: EdgeInsets.symmetric(vertical: h * 0.01),
-      child: InkWell(
-        onTap: isLink ? () => _openLink(text) : null,
-        child: Row(
+      child: Row(
           children: [
             Icon(icon, size: w * 0.048, color: AppColors.grey),
             SizedBox(width: w * 0.03),
-            Expanded(
-              child: Text(
-                text,
+            Flexible(
+              child: LinkText(
+                text: text,
                 style: AppTextStyles.caption(context).copyWith(
-                  color: isLink ? Colors.blue : Colors.white,
-                  decoration: isLink ? TextDecoration.underline : null,
+                  color: Colors.white,
                 ),
+                maxLines: 3,
               ),
             ),
           ],
         ),
-      ),
-    );
+      );
   }
 }

--- a/lib/screen/mentor-evaluation/view/evaluation_screen_returned_tasks.dart
+++ b/lib/screen/mentor-evaluation/view/evaluation_screen_returned_tasks.dart
@@ -8,7 +8,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ammentor/screen/mentor-evaluation/model/mentee_tasks_model.dart';
 import 'package:ammentor/screen/mentor-evaluation/provider/evaluation_provider.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:ammentor/components/link_text.dart';
 
 /// Updated to accept trackId dynamically
 final submissionProvider = FutureProvider.family<
@@ -247,51 +247,23 @@ class _TaskEvaluationViewScreenState
     final screenHeight = MediaQuery.of(context).size.height;
     final screenWidth = MediaQuery.of(context).size.width;
 
-    final isLink = text.isNotEmpty &&
-        text.toLowerCase() != "no link" &&
-        (text.startsWith("http") || text.startsWith("www") || text.contains("."));
-
-    Future<void> _openLink(String url) async {
-      String normalized = url.trim();
-
-      if (!normalized.startsWith('http://') &&
-          !normalized.startsWith('https://')) {
-        normalized = 'https://$normalized';
-      }
-
-      final uri = Uri.tryParse(normalized);
-
-      if (uri != null && await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text("Invalid or unreachable link")),
-        );
-      }
-    }
-
     return Padding(
       padding: EdgeInsets.symmetric(vertical: screenHeight * 0.01),
-      child: InkWell(
-        onTap: isLink ? () => _openLink(text) : null,
-        child: Row(
+      child: Row(
           children: [
             Icon(icon, color: AppColors.grey),
             SizedBox(width: screenWidth * 0.02),
             Flexible(
-              child: Text(
-                text,
+              child: LinkText(
+                text: text,
                 style: AppTextStyles.caption(context).copyWith(
-                  color: isLink ? Colors.blue : Colors.white,
-                  decoration: isLink ? TextDecoration.underline : null,
+                  color: Colors.white,
                 ),
-                overflow: TextOverflow.ellipsis,
                 maxLines: 3,
               ),
             ),
           ],
         ),
-      ),
-    );
+      );
   }
 }


### PR DESCRIPTION
Fixes #49 and #50 

When text and a URL appear together on the mentor evaluation page, only the URL is treated as a clickable link. Mentor remarks are no longer incorrectly rendered as links.