### PR TITLE
feat(mentor-evaluation): add mentee search with real-time filtering

### DIFF
--- a/lib/screen/mentor-evaluation/view/mentee_list_screen.dart
+++ b/lib/screen/mentor-evaluation/view/mentee_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ammentor/components/theme.dart';
 import 'package:ammentor/components/mentee_tile.dart';
+import 'package:ammentor/components/custom_text_field.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ammentor/screen/mentor-evaluation/view/mentee_tasks_screen.dart';
 import 'package:ammentor/screen/mentor-evaluation/provider/mentee_list_provider.dart';
@@ -15,6 +16,8 @@ class MenteeListScreen extends ConsumerStatefulWidget {
 class _MenteeListScreenState extends ConsumerState<MenteeListScreen>
     with SingleTickerProviderStateMixin {
   AnimationController? _animationController;
+  final TextEditingController searchController = TextEditingController();
+  String searchQuery = '';
 
   @override
   void initState() {
@@ -27,6 +30,7 @@ class _MenteeListScreenState extends ConsumerState<MenteeListScreen>
 
   @override
   void dispose() {
+    searchController.dispose();
     _animationController?.dispose();
     super.dispose();
   }
@@ -63,19 +67,43 @@ class _MenteeListScreenState extends ConsumerState<MenteeListScreen>
                 color: AppColors.grey,
                 thickness: 1.0,
               ),),
+
+            SizedBox(height: screenHeight * 0.01),
+
+            CustomTextField(
+              controller: searchController,
+              label: "Search",
+              hintText: "Search Mentee...",
+              onChanged: (value) {
+                setState(() {
+                  searchQuery = value;
+                });
+              },
+              width: screenWidth,
+            ),
+
+            SizedBox(height: screenHeight * 0.01),
+            
             Expanded(
               child: menteesAsync.when(
                 data: (mentees) {
-                  if (mentees.isEmpty) {
-                    return Center(child: Text('No mentees found', style: AppTextStyles.caption(context)));
+                  final filteredMentees = mentees.where((mentee) {
+                    return mentee.name
+                        .toLowerCase()
+                        .contains(searchQuery.toLowerCase());
+                  }).toList();
+
+                  if (filteredMentees.isEmpty) {
+                    return Center(child: Text(searchQuery.isEmpty ? 'No mentees available' : "No mentees found", style: AppTextStyles.caption(context)));
                   }
+
                   return AnimatedBuilder(
                     animation: _animationController!,
                     builder: (context, child) {
                       return ListView.builder(
-                        itemCount: mentees.length,
+                        itemCount: filteredMentees.length,
                         itemBuilder: (context, index) {
-                          final mentee = mentees[index];
+                          final mentee = filteredMentees[index];
                           return FadeTransition(
                             opacity: Tween<double>(begin: 0, end: 1).animate(
                               CurvedAnimation(


### PR DESCRIPTION
# Description

Added a search feature in the Evaluation Tab so mentors can quickly find mentees by name instead of scrolling through a long list.

With this update:
- A search input is shown above the mentee list
- Results filter in real time as you type
- The search works in a case-insensitive way
- Clearing the search brings back the full list
- A proper empty state appears when no results are found

This makes the Evaluation Tab more usable as the number of mentees grows.

---

# Acceptance Criteria

- [x] Search input above the mentee list (Evaluation Tab - Mentor View)
- [x] Real-time filtering as user types
- [x] Case-insensitive name matching
- [x] Clearing search restores full list
- [x] Empty state shown when no results

---

# Screenshots

| Description | Screenshot |
|------------|-----------|
| Search with results | ![](https://github.com/user-attachments/assets/6e165c4f-8968-45e0-b80e-5cd50a5ded7b) |
| No results empty state | ![](https://github.com/user-attachments/assets/bd39526e-d482-482c-9ed0-c38653abe80f) |
| Full list after clearing search | ![](https://github.com/user-attachments/assets/1c49a394-f51e-44fa-b600-c708a6b1a839) |

---

# Notes

- Search uses the existing CustomTextField component
- Empty states are handled for both no data and no matches

---

# Testing

- Verified real-time filtering works
- Empty state displays correctly
- Clearing search restores the list
- Case-insensitive matching confirmed

---

# Related Issue

- #60